### PR TITLE
Add camera stop control and start game paused

### DIFF
--- a/src/HandPong.tsx
+++ b/src/HandPong.tsx
@@ -13,7 +13,7 @@ import { clamp } from './utils/mathUtils';
 
 const HandPong = () => {
     // Game and UI state
-    const [running, setRunning] = useState(true);
+    const [running, setRunning] = useState(false);
     const [status, setStatus] = useState('Idle');
     const [mouseMode, setMouseMode] = useState(false);
     const [showPreview, setShowPreview] = useState(true);
@@ -22,6 +22,7 @@ const HandPong = () => {
     const [sensitivity, setSensitivity] = useState(1.0);
     const [handsFPS, setHandsFPS] = useState(0);
     const [handSeen, setHandSeen] = useState(false);
+    const [cameraRunning, setCameraRunning] = useState(false);
 
     // Canvas ref
     const canvasRef = useRef<HTMLCanvasElement>(null!) as React.RefObject<HTMLCanvasElement>;
@@ -54,7 +55,9 @@ const HandPong = () => {
 
     // Now we can use the tracking hook with the defined handlers
     type StartCameraFn = () => Promise<void>;
+    type StopCameraFn = () => void;
     const startCameraRef = useRef<StartCameraFn | null>(null);
+    const stopCameraRef = useRef<StopCameraFn | null>(null);
 
     // Safely set top limit
     const setTopSafe = (v: number) => {
@@ -75,6 +78,8 @@ const HandPong = () => {
         try {
             if (startCameraRef.current) {
                 await startCameraRef.current();
+                setCameraRunning(true);
+                setMouseMode(false);
             } else {
                 throw new Error("Camera not initialized");
             }
@@ -82,6 +87,14 @@ const HandPong = () => {
             console.error("Camera error:", e);
             setMouseMode(true);
         }
+    };
+
+    const handleStopCamera = () => {
+        if (stopCameraRef.current) {
+            stopCameraRef.current();
+        }
+        setCameraRunning(false);
+        setMouseMode(true);
     };
 
     // Game update loop
@@ -128,6 +141,8 @@ const HandPong = () => {
 
                 <Toolbar
                     startCamera={handleStartCamera}
+                    stopCamera={handleStopCamera}
+                    cameraRunning={cameraRunning}
                     mouseMode={mouseMode}
                     setMouseMode={setMouseMode}
                     running={running}
@@ -163,6 +178,7 @@ const HandPong = () => {
                     top={top}
                     bottom={bottom}
                     startCameraRef={startCameraRef}
+                    stopCameraRef={stopCameraRef}
                 />
             </ControlPanel>
         </main>

--- a/src/components/HandTracker.tsx
+++ b/src/components/HandTracker.tsx
@@ -9,6 +9,7 @@ interface HandTrackerProps {
     top: number;
     bottom: number;
     startCameraRef?: React.RefObject<(() => Promise<void>) | null>;
+    stopCameraRef?: React.RefObject<(() => void) | null>;
 };
 
 const HandTracker = ({
@@ -19,9 +20,10 @@ const HandTracker = ({
     showPreview,
     top,
     bottom,
-    startCameraRef
+    startCameraRef,
+    stopCameraRef
 }: HandTrackerProps) => {
-    const { videoRef, debugRef, startCamera } = useHandTracking({
+    const { videoRef, debugRef, startCamera, stopCamera } = useHandTracking({
         mirror,
         showPreview,
         top,
@@ -33,6 +35,10 @@ const HandTracker = ({
 
     if (startCameraRef) {
         startCameraRef.current = startCamera;
+    };
+
+    if (stopCameraRef) {
+        stopCameraRef.current = stopCamera;
     };
 
     return (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,5 +1,7 @@
 interface ToolbarProps {
     startCamera: () => void;
+    stopCamera: () => void;
+    cameraRunning: boolean;
     mouseMode: boolean;
     setMouseMode: (mode: boolean) => void;
     running: boolean;
@@ -10,6 +12,8 @@ interface ToolbarProps {
 
 const Toolbar = ({
   startCamera,
+  stopCamera,
+  cameraRunning,
   mouseMode,
   setMouseMode,
   running,
@@ -21,6 +25,10 @@ const Toolbar = ({
         <div className="toolbar" style={{ marginTop: 12 }}>
             <button className="btn" onClick={startCamera}>
                 🎥 Start Camera
+            </button>
+
+            <button className="btn" onClick={stopCamera} disabled={!cameraRunning}>
+                🛑 Stop Camera
             </button>
 
             <button


### PR DESCRIPTION
## Summary
- start game paused by default
- add toolbar button and hook support to stop camera

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a433a94a848332b833e50b90ff8cec